### PR TITLE
When failing to parse address, retry with text after the first comma.

### DIFF
--- a/utils/location.py
+++ b/utils/location.py
@@ -126,6 +126,14 @@ def get_address(full_location):
             location = cache[full_location]
         else:
             location = geolocator.geocode(full_location, addressdetails=True)
+            if location is None and "," in full_location:
+                partial_location = full_location.split(",", 1)[1]
+                if partial_location in cache:
+                    location = cache[partial_location]
+                else:
+                    logging.warning(f"Retrying address parse with {partial_location}...")
+                    location = geolocator.geocode(partial_location, addressdetails=True)
+                    cache[partial_location] = location
             cache[full_location] = location
 
         if location is None:


### PR DESCRIPTION
This enables parsing addresses which start with a location name unknown to OSM, for example:

Haus pour bienne (confirmer en fonction de la date choisie), Rue du Controle 22, Bienne, Suisse
3DD espace de concertation, Rue David-Dufour 3, 1205 Geneve, Suisse
Naldeo, 222 Cours Lafayette, 69003 Lyon, France
L'autre Cote, Rue Saint-Pierre 10, 7700 Mouscron, Belgium

The fix could be taken further by trying again. This example does not parse but would with a second retry:

Maison De L'environnement, Hyeres, 17 Rue Ernest Reyer, 83400 Hyeres, France

The risk of parsing a location that is not detailed enough is already handled by the code looking for a "road" or "square". Examples that still do not and should not parse:

La Maison du Zero Dechet, Passage Jaqueline Giraud, Paris, France
Le Jardin aux Dragons, Saint-Andre-des-Eaux, France