### PR TITLE
feat: support different workshop languages.

### DIFF
--- a/apis/glorieuses.py
+++ b/apis/glorieuses.py
@@ -156,6 +156,7 @@ def get_glorieuses_data(source):
             country_code,
             latitude,
             longitude,
+            source.get("language_code"),
             online,
             training,
             sold_out,

--- a/countries/ch.json
+++ b/countries/ch.json
@@ -36,19 +36,11 @@
         "id": 3
     },
     {
-        "name": "Digital Puzzle",
-        "language": "de",
-        "url": "https://www.billetweb.fr/digital-collage-dach&multi=12991&language=en&color=5190F5&parent=1&language=en&color=5190F5",
-        "type": "scraper",
-        "iframe": "eventdigital-collage-dach",
-        "id": 3
-    },
-    {
         "name": "Digital Collage",
         "language": "en",
-        "url": "https://www.billetweb.fr/united-kingdom-digital-collage&multi=12991&language=en&color=5190F5&parent=1&language=en&color=5190F5",
+        "url": "https://www.billetweb.fr/multi_event.php?multi=12991",
         "type": "scraper",
-        "iframe": "eventunited-kingdom-digital-collage",
+        "iframe": "multi_event_list"
         "id": 3
     },
     {

--- a/countries/ch.json
+++ b/countries/ch.json
@@ -21,10 +21,34 @@
         "id": 2
     },
     {
+        "name": "Biodiversity Collage",
+        "language": "en",
+        "url": "https://www.billetweb.fr/biodiversity-collage-zurich-switzerland&multi=17309&margin=no_margin&color=99ad23&parent=fresquedelabiodiversite&margin=no_margin&color=99ad23A",
+        "type": "scraper",
+        "iframe": "event17309",
+        "id": 2
+    },
+    {
         "name": "Fresque du Numérique",
         "url": "https://www.billetweb.fr/shop.php?event=suisse-atelier-fresque-du-numerique&color=5190f5&page=1&margin=no_margin",
         "type": "scraper",
         "iframe": "eventu84999",
+        "id": 3
+    },
+    {
+        "name": "Digital Puzzle",
+        "language": "de",
+        "url": "https://www.billetweb.fr/digital-collage-dach&multi=12991&language=en&color=5190F5&parent=1&language=en&color=5190F5",
+        "type": "scraper",
+        "iframe": "eventdigital-collage-dach",
+        "id": 3
+    },
+    {
+        "name": "Digital Collage",
+        "language": "en",
+        "url": "https://www.billetweb.fr/united-kingdom-digital-collage&multi=12991&language=en&color=5190F5&parent=1&language=en&color=5190F5",
+        "type": "scraper",
+        "iframe": "eventunited-kingdom-digital-collage",
         "id": 3
     },
     {
@@ -115,6 +139,24 @@
         "url": "https://climatefresk.org/fr-ch/inscription-atelier/grand-public/",
         "type": "scraper",
         "id": 200
+    },
+        {
+        "name": "Climate Fresk (workshops)",
+        "url": "https://climatefresk.org/de-ch/workshop-anmeldung/offentlichkeit/",
+        "type": "scraper",
+        "id": 200
+    },
+    {
+        "name": "Fresque de l'Economie Circulaire",
+        "url": "https://www.billetweb.fr/pro/lafresquedeleconomiecirculaire",
+        "type": "scraper",
+        "id": 300
+    },
+    {
+        "name": "Circular Economy Collage",
+        "url": "https://www.eventbrite.fr/o/fresque-de-leconomie-circulaire-68155531313",
+        "type": "scraper",
+        "id": 300
     },
     {
         "name": "Fresque des Frontières Planétaires (ateliers)",

--- a/db/etl.py
+++ b/db/etl.py
@@ -46,7 +46,7 @@ def insert(conn, df, table, most_recent=False):
     cursor = conn.cursor()
     try:
         cursor.executemany(
-            "INSERT INTO %s(%s) VALUES (%%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s)"
+            "INSERT INTO %s(%s) VALUES (%%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s, %%s)"
             % (table, cols),
             tuples,
             returning=True,

--- a/db/records.py
+++ b/db/records.py
@@ -19,6 +19,7 @@ def get_record_dict(
     country_code,
     latitude,
     longitude,
+    language_code,
     online,
     training,
     sold_out,
@@ -45,6 +46,9 @@ def get_record_dict(
         "country_code": country_code,
         "latitude": latitude,
         "longitude": longitude,
+        "language_code": (
+            language_code.strip() if bool(language_code and language_code.strip()) else "fr"
+        ),
         "online": online,
         "training": training,
         "sold_out": sold_out,

--- a/scraper/billetweb.py
+++ b/scraper/billetweb.py
@@ -282,7 +282,7 @@ def get_billetweb_data(sources, service, options):
                     country_code,
                     latitude,
                     longitude,
-                    page["language_code"],
+                    page.get("language_code"),
                     online,
                     training,
                     sold_out,

--- a/scraper/billetweb.py
+++ b/scraper/billetweb.py
@@ -282,6 +282,7 @@ def get_billetweb_data(sources, service, options):
                     country_code,
                     latitude,
                     longitude,
+                    page["language_code"],
                     online,
                     training,
                     sold_out,

--- a/scraper/eventbrite.py
+++ b/scraper/eventbrite.py
@@ -362,6 +362,7 @@ def get_eventbrite_data(sources, service, options):
                     country_code,
                     latitude,
                     longitude,
+                    page["language_code"],
                     online,
                     training,
                     sold_out,

--- a/scraper/eventbrite.py
+++ b/scraper/eventbrite.py
@@ -362,7 +362,7 @@ def get_eventbrite_data(sources, service, options):
                     country_code,
                     latitude,
                     longitude,
-                    page["language_code"],
+                    page.get("language_code"),
                     online,
                     training,
                     sold_out,

--- a/scraper/fdc.py
+++ b/scraper/fdc.py
@@ -95,11 +95,11 @@ def get_fdc_data(sources, service, options):
                     parent = globe_in_event.find_element(By.XPATH, "..")
                     language_code = get_language_code(parent.text)
                 except FreskLanguageNotRecognized as e:
-                    logging.warning(f"Assuming workshop language as French: {e}")
-                    language_code = "fr"
+                    logging.warning(f"Unable to parse workshop language: {e}")
+                    language_code = None
                 except NoSuchElementException:
-                    logging.warning("Unable to find workshop language, assuming French.")
-                    language_code = "fr"
+                    logging.warning("Unable to find workshop language on the page.")
+                    language_code = None
 
                 ################################################################
                 # Is it an online event?

--- a/scraper/fdc.py
+++ b/scraper/fdc.py
@@ -11,8 +11,9 @@ from selenium.webdriver.support import expected_conditions as EC
 
 from db.records import get_record_dict
 from utils.date_and_time import get_dates
-from utils.errors import FreskError, FreskDateBadFormat
+from utils.errors import FreskError, FreskDateBadFormat, FreskLanguageNotRecognized
 from utils.keywords import *
+from utils.language import get_language_code
 from utils.location import get_address
 
 
@@ -82,6 +83,23 @@ def get_fdc_data(sources, service, options):
                     iframe = wait.until(EC.presence_of_element_located((By.TAG_NAME, "iframe")))
                     driver.switch_to.frame(iframe)
                     continue
+
+                ################################################################
+                # Workshop language
+                ################################################################
+                language_code = None
+                try:
+                    globe_in_event = driver.find_element(
+                        By.XPATH, '//div[contains(@class, "mb-3")]/i[contains(@class, "fa-globe")]'
+                    )
+                    parent = globe_in_event.find_element(By.XPATH, "..")
+                    language_code = get_language_code(parent.text)
+                except FreskLanguageNotRecognized as e:
+                    logging.warning(f"Assuming workshop language as French: {e}")
+                    language_code = "fr"
+                except NoSuchElementException:
+                    logging.warning("Unable to find workshop language, assuming French.")
+                    language_code = "fr"
 
                 ################################################################
                 # Is it an online event?
@@ -182,6 +200,7 @@ def get_fdc_data(sources, service, options):
                     country_code,
                     latitude,
                     longitude,
+                    language_code,
                     online,
                     training,
                     sold_out,

--- a/scraper/fec.py
+++ b/scraper/fec.py
@@ -233,7 +233,7 @@ def get_fec_data(sources, service, options):
                 country_code,
                 latitude,
                 longitude,
-                page["language_code"],
+                page.get("language_code"),
                 online,
                 training,
                 sold_out,

--- a/scraper/fec.py
+++ b/scraper/fec.py
@@ -233,6 +233,7 @@ def get_fec_data(sources, service, options):
                 country_code,
                 latitude,
                 longitude,
+                page["language_code"],
                 online,
                 training,
                 sold_out,

--- a/scraper/glide.py
+++ b/scraper/glide.py
@@ -233,6 +233,7 @@ def get_glide_data(sources, service, options):
                     country_code,
                     latitude,
                     longitude,
+                    page["language_code"],
                     online,
                     training,
                     sold_out,

--- a/scraper/glide.py
+++ b/scraper/glide.py
@@ -233,7 +233,7 @@ def get_glide_data(sources, service, options):
                     country_code,
                     latitude,
                     longitude,
-                    page["language_code"],
+                    page.get("language_code"),
                     online,
                     training,
                     sold_out,

--- a/scraper/helloasso.py
+++ b/scraper/helloasso.py
@@ -214,6 +214,7 @@ def get_helloasso_data(sources, service, options):
                 country_code,
                 latitude,
                 longitude,
+                page["language_code"],
                 online,
                 training,
                 sold_out,

--- a/scraper/helloasso.py
+++ b/scraper/helloasso.py
@@ -214,7 +214,7 @@ def get_helloasso_data(sources, service, options):
                 country_code,
                 latitude,
                 longitude,
-                page["language_code"],
+                page.get("language_code"),
                 online,
                 training,
                 sold_out,

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -44,3 +44,9 @@ class FreskCountryNotSupported(FreskError):
             f'Address "{address}" is not located in a supported country (input: {input_str}).'
         )
         super().__init__(self.message)
+
+
+class FreskLanguageNotRecognized(FreskError):
+    def __init__(self, language_text: str):
+        self.message = f'Language "{language_text}" is not recognized.'
+        super().__init__(self.message)

--- a/utils/language.py
+++ b/utils/language.py
@@ -1,0 +1,24 @@
+import logging
+
+from utils.errors import FreskLanguageNotRecognized
+
+
+def get_language_code(language_text):
+    """
+    Returns the ISO 639-1 language code given a human-readable string such as "Français" or "English".
+    """
+    language_codes = {
+        "Allemand": "de",
+        "Anglais": "en",
+        "Deutsch": "de",
+        "Englisch": "en",
+        "English": "en",
+        "Französisch": "fr",
+        "Français": "fr",
+        "Français": "fr",
+        "German": "de",
+    }
+    language_code = language_codes.get(language_text)
+    if not language_code:
+        raise FreskLanguageNotRecognized(language_text)
+    return language_code


### PR DESCRIPTION
All events contain an output "language_code" set by one of the following:

* An optional "language_code" key in the scraper configuration. The configuration for Switzerland gains a few workshops, for example Digital Collage in English and Digital Puzzle in German.

* The scraper extracts the language from the event page for the ticketing platforms that support it, such as Climate Fresk.

If all else fails, the fallback is "fr" for French.

Add an utility to convert the human string for a language (ex: "German") to its language code, and a new FreskLanguageNotRecognized error.