### PR TITLE
feat: parse iCalendar events

### DIFF
--- a/apis/ics.py
+++ b/apis/ics.py
@@ -1,0 +1,130 @@
+import csv
+import datetime
+import json
+import pytz
+import requests
+import logging
+
+from db.records import get_record_dict
+from ics import Calendar
+from utils.errors import FreskError
+from utils.location import get_address
+
+
+def get_ics_data(source):
+    logging.info("Getting data from ICS file in iCalendar format")
+
+    calendar = None
+    records = []
+
+    try:
+        response = requests.get(source["url"])
+        # Check if the request was successful (status code 200)
+        if response.status_code == 200:
+            calendar = Calendar(response.text)
+        else:
+            logging.info(f"Request failed with status code: {response.status_code}")
+    except requests.RequestException as e:
+        logging.info(f"An error occurred: {e}")
+
+    if not calendar:
+        return records
+
+    for event in calendar.events:
+
+        ################################################################
+        # Kick out event early if it is in the past
+        ################################################################
+        event_start_datetime = event.begin
+        event_end_datetime = event.end
+        if event_start_datetime < pytz.UTC.localize(datetime.datetime.now()):
+            continue
+
+        ################################################################
+        # Get basic event metadata
+        ################################################################
+        event_id = event.uid
+        title = event.name
+        description = event.description
+
+        ################################################################
+        # Location data, or online
+        ################################################################
+        full_location = ""
+        location_name = ""
+        address = ""
+        city = ""
+        department = ""
+        longitude = ""
+        latitude = ""
+        zip_code = ""
+        country_code = ""
+
+        online = event.location == None
+        if not online:
+            try:
+                full_location = event.location
+                address_dict = get_address(full_location.split("\n", 1).pop())
+                (
+                    location_name,
+                    address,
+                    city,
+                    department,
+                    zip_code,
+                    country_code,
+                    latitude,
+                    longitude,
+                ) = address_dict.values()
+            except FreskError as error:
+                logging.info(f"Rejecting record: {error}.")
+                continue
+
+        ################################################################
+        # Infer more event metadata
+        ################################################################
+        title_upper = title.upper()
+        training = "FORMATION" in title_upper or "TRAINING" in title_upper
+        sold_out = False
+        kids = False
+
+        ################################################################
+        # Get tickets link (more sophisticated parsing to be added later)
+        ################################################################
+        tickets_link = event.url
+        source_link = tickets_link
+        if not tickets_link:
+            logging.info(f"Rejecting record {event_id}: no ticket link extracted.")
+            continue
+
+        ################################################################
+        # Building final object
+        ################################################################
+        record = get_record_dict(
+            f"{source['id']}-{event_id}",
+            source["id"],
+            title,
+            event_start_datetime,
+            event_end_datetime,
+            full_location,
+            location_name,
+            address,
+            city,
+            department,
+            zip_code,
+            country_code,
+            latitude,
+            longitude,
+            online,
+            training,
+            sold_out,
+            kids,
+            source_link,
+            tickets_link,
+            description,
+        )
+
+        records.append(record)
+        logging.info(f"Successfully got record\n{json.dumps(record, indent=4)}")
+
+    logging.info(f"Got {len(records)} records.")
+    return records

--- a/apis/main.py
+++ b/apis/main.py
@@ -1,8 +1,13 @@
 import pandas as pd
 
+from apis.ics import get_ics_data
 from apis.glorieuses import get_glorieuses_data
 
-APIS_FNS = {"hook.eu1.make.com": get_glorieuses_data}
+APIS_FNS = {
+    "hook.eu1.make.com": get_glorieuses_data,
+    "calendar.google.com/calendar/ical": get_ics_data,
+    "framagenda.org/remote.php/dav": get_ics_data,
+}
 
 
 def main(apis):

--- a/countries/ch.json
+++ b/countries/ch.json
@@ -122,5 +122,23 @@
         "type": "scraper",
         "filter": "Fresque des frontières planétaires",
         "id": 500
+    },
+    {
+        "name": "Planet C Play Again?",
+        "url": "https://calendar.google.com/calendar/ical/2fe1be9f8d5c073969bccaba14133699b71305877304056bee924ee0ef128977%40group.calendar.google.com/public/basic.ics",
+        "type": "api",
+        "id": 800
+    },
+    {
+        "name": "Fresque du Sol",
+        "url": "https://framagenda.org/remote.php/dav/public-calendars/KwNwGA232xD38CnN/?export",
+        "type": "api",
+        "id": 801
+    },
+    {
+        "name": "Fresque des Déchets",
+        "url": "https://calendar.google.com/calendar/ical/greendonut.info%40gmail.com/public/basic.ics",
+        "type": "api",
+        "id": 802
     }
 ]

--- a/countries/ch.json
+++ b/countries/ch.json
@@ -134,11 +134,5 @@
         "url": "https://framagenda.org/remote.php/dav/public-calendars/KwNwGA232xD38CnN/?export",
         "type": "api",
         "id": 801
-    },
-    {
-        "name": "Fresque des Déchets",
-        "url": "https://calendar.google.com/calendar/ical/greendonut.info%40gmail.com/public/basic.ics",
-        "type": "api",
-        "id": 802
     }
 ]

--- a/countries/ch.json
+++ b/countries/ch.json
@@ -85,6 +85,12 @@
         "id": 14
     },
     {
+        "name": "Fresque des Déchets,
+        "url": "https://calendar.google.com/calendar/ical/greendonut.info%40gmail.com/public/basic.ics",
+        "type": "api",
+        "id": 15
+    },
+    {
         "name": "Puzzle Climat",
         "url": "https://www.billetweb.fr/multi_event.php?user=121600",
         "type": "scraper",

--- a/countries/ch.json
+++ b/countries/ch.json
@@ -85,7 +85,7 @@
         "id": 14
     },
     {
-        "name": "Fresque des Déchets,
+        "name": "Fresque des Déchets",
         "url": "https://calendar.google.com/calendar/ical/greendonut.info%40gmail.com/public/basic.ics",
         "type": "api",
         "id": 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "geopy>=2.4.1",
+    "ics>=0.7.2",
     "numpy>=2.1.3",
     "pandas>=2.2.3",
     "psycopg>=3.2.3",


### PR DESCRIPTION
The [ics library](https://icspy.readthedocs.io/en/stable/index.html) makes it easy. This closes #28 although with followup work (documentation, extract link from description).

Events starting before the current date or from which no ticketing link can be extracted are skipped.