### PR TITLE
feat: parse ticketing link from iCal event description

### DIFF
--- a/apis/ics_test.py
+++ b/apis/ics_test.py
@@ -1,0 +1,28 @@
+import logging
+
+from apis import ics
+
+
+def run_tests():
+    long_url = "https://www.eventbrite.com/e/2tonnes-world-workshop-in-basel-switzerland-tickets-1116862910029?aff=odcleoeventsincollection&keep_tld=1"
+    test_cases = [
+        ("text_url", long_url, long_url),
+        (
+            "html_with_extra text",
+            '<html><body>Tickets here: <a href="http://result">registration</a>. Come and have fun!</body></html>',
+            "http://result",
+        ),
+        ("text_and_url", "Lien d'inscription : http://result.org", "http://result.org"),
+        (
+            "more_text_and_url",
+            "Fresque du sol animée en ligne.\nInscription obligatoire https://www.billetweb.fr/fresque-du-sol-en-ligne11\nContact si besoinnoone@nowhere.fr.",
+            "https://www.billetweb.fr/fresque-du-sol-en-ligne11",
+        ),
+    ]
+    for test_case in test_cases:
+        logging.info(f"Running {test_case[0]}")
+        actual = ics.get_ticketing_url_from_description(test_case[1])
+        if actual == test_case[2]:
+            logging.info("Result matches")
+        else:
+            logging.error(f"{test_case[0]}: expected {test_case[2]} but got {actual}")

--- a/scrape_test.py
+++ b/scrape_test.py
@@ -1,0 +1,5 @@
+from apis import ics_test
+
+
+if __name__ == "__main__":
+    ics_test.run_tests()


### PR DESCRIPTION
Implements #56 by enumerating and filtering URLs present in the event description. This recovers 18 events for Fresque des Déchets.

Adds a test suite as well, with only test cases for the new functionality for now. It is not required to run the scraper. However, it makes it much faster to iterate on and debug descriptions which cannot be parsed.