### PR TITLE
fix: remove VALARMs (reminders) from iCalendar events to work around ICS library crash

### DIFF
--- a/apis/ics.py
+++ b/apis/ics.py
@@ -2,6 +2,7 @@ import csv
 import datetime
 import json
 import pytz
+import re
 import requests
 import logging
 
@@ -19,9 +20,11 @@ def get_ics_data(source):
 
     try:
         response = requests.get(source["url"])
-        # Check if the request was successful (status code 200)
+        # Check if the request was successful (status code 200).
         if response.status_code == 200:
-            calendar = Calendar(response.text)
+            # Remove VALARMs which incorrectly crash the ics library.
+            text = re.sub("BEGIN:VALARM.*END:VALARM", "", response.text, flags=re.DOTALL)
+            calendar = Calendar(text)
         else:
             logging.info(f"Request failed with status code: {response.status_code}")
     except requests.RequestException as e:

--- a/scrape.py
+++ b/scrape.py
@@ -122,13 +122,17 @@ if __name__ == "__main__":
         default=False,
         help="push the scraped results to db",
     )
+    parser.add_argument(
+        "--skip-dirty-check",
+        action="store_true",
+        default=False,
+        help="skips checking that the git repository is clean",
+    )
     args = parser.parse_args()
 
-    dirty = False
-
     # This scraper should be run from a clean state to ensure reproducibility
-    if is_git_repository_dirty():
-        dirty = True
+    dirty = is_git_repository_dirty()
+    if dirty and not args.skip_dirty_check:
         logging.warning("The git repository is dirty. Consider a clean state for reproducibility.")
         user_input = input("Do you want to continue? (y/n): ").strip().lower()
         if user_input != "y":


### PR DESCRIPTION
The Fresque du Sol file contains a reminder with the `DISPLAY` action type for an event on December 5, 2023. The event can be seen on the calendar on the [workshop page](https://fresquedusol.com/comment-participer/dates-a-venir/).

```
BEGIN:VEVENT
[...]
DTSTART;TZID=Europe/Paris:20231205T184500
DTEND;TZID=Europe/Paris:20231205T222000
[...]
BEGIN:VALARM
ACTION:DISPLAY
TRIGGER;RELATED=START:-P2D
END:VALARM
END:VEVENT
```

According to [the specification](https://icalendar.org/iCalendar-RFC-5545/3-6-6-alarm-component.html), the reminder should contain a `DESCRIPTION`. It doesn't. The ics library throws `ValueError: A VALARM must have at least one DESCRIPTION` when reading the file.

Unfortunately, this discards the entire file with all other past and future events. Removing the alarm from the event or [fixing the Framagenda export](https://framacolibri.org/t/export-dun-evenement-avec-notification-pas-compatible-avec-la-specification-ics/25864) or adding functionality to the ics library to ignore such cases will take a while. Since we ignore reminders anyway, it's faster and easier to strip them before parsing the file.