### PR TITLE
[WIP] Detect event language automatically

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "geopy>=2.4.1",
     "ics>=0.7.2",
+    "langdetect>=1.0.9",
     "numpy>=2.1.3",
     "pandas>=2.2.3",
     "psycopg>=3.2.3",

--- a/scraper/billetweb.py
+++ b/scraper/billetweb.py
@@ -3,6 +3,7 @@ import json
 import logging
 from datetime import timedelta
 
+from langdetect import detect
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver.common.by import By
@@ -259,6 +260,11 @@ def get_billetweb_data(sources, service, options):
                     except FreskError as error:
                         logging.info(f"Rejecting record: {error}.")
                         continue
+
+                # Language?
+                # TODO: move to record construction once #53 is in
+                language_code = page.get("language_code", detect(title + description))
+                logging.info(f"LANGUAGE DETECTED: {language_code}")
 
                 # Training?
                 training = is_training(title)


### PR DESCRIPTION
This fixes #40 by passing the title and description to [langdetect](https://pypi.org/project/langdetect/).

Working examples:
* Correctly detected as EN: https://www.billetweb.fr/shop.php?event=913994&margin=no_margin&color=5190f5&cross_shop=41180&step=1&session=11324288
* Correctly detected as French: https://www.billetweb.fr/shop.php?event=909349&margin=no_margin&color=5190f5&cross_shop=41180&step=1&session=11162448
* Incorrectly detected as English, it should be Italian: https://www.billetweb.fr/shop.php?event=1084577&margin=no_margin&color=5190f5&cross_shop=41180&step=1&session=11247812